### PR TITLE
Implement documentation generation for components

### DIFF
--- a/bin/generate_site.dart
+++ b/bin/generate_site.dart
@@ -5,6 +5,8 @@
 
 import 'dart:convert';
 import 'dart:io';
+
+import 'package:path/path.dart' show join;
 import 'package:mustache/mustache.dart' as mustache;
 
 //---------------------------------------------------------------------
@@ -26,8 +28,36 @@ Map getComponentInformation(String name) {
   return {
     'name': className,
     'path': 'components/$name/',
+    'filename': '${name}.dart',
     'tag': tagName
   };
+}
+
+void buildDocs(List<String> sourceFiles) {
+  // Generate the docs
+  var docgenArgs = ['-j', '-v', '--include-private', '--no-include-sdk',
+              '--no-include-dependent-packages', '--package-root=./packages'];
+  docgenArgs.addAll(sourceFiles);
+  // TODO: fix workingDirectory
+  ProcessResult processResult =
+      Process.runSync('docgen', docgenArgs, workingDirectory: '../');
+  if (processResult.stderr != '') {
+    print("failed to create docs: ${processResult.stderr}");
+  }
+
+  print("processResult ${processResult.stdout}");
+}
+
+String getOverview(Map component) {
+  var docNamePart = component["filename"]
+                    .substring(0, component["filename"].length - 5);
+  var docFile = join('../', 'docs', 'pixelate', 'pixelate_${docNamePart}.json');
+  var docData = readJsonFile(docFile) as Map;
+  var docClass = (docData["classes"]["class"] as List)
+      .firstWhere((e) => e["name"] == component['name']);
+  // TODO: is "preview" the right element we want? How about "comment"
+  var overview = docClass["preview"] == null ? "" : docClass["preview"];
+  return overview;
 }
 
 List<String> findComponents(String path) {
@@ -134,6 +164,13 @@ void main() {
   var siteTemplate = readMustacheTemplate('site_template.html');
   var template = readMustacheTemplate('component_template.html');
 
+  // Generate the docs
+  var sourceFiles = groups
+      .map((g) => g['components']
+      .map((c) => join('lib', c["path"], c["filename"])))
+      .expand((i) => i).toList();
+  buildDocs(sourceFiles);
+
   // Generate the components
   groups.forEach((group) {
     var components = group['components'] as List;
@@ -141,10 +178,11 @@ void main() {
     components.forEach((component) {
       var path = component['path'];
       var name = component['name'];
+
       var partial = {
           'groups': groups,
           'tag': component['tag'],
-          'overview': '<p>Description goes here</p>',
+          'overview': getOverview(component),
           'examples': getExamples(path)
       };
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dev_dependencies:
   pixelate_flat:
     path: ../pixelate-flat
   unittest: any
+  path: any
 transformers:
 - polymer:
     entry_points:


### PR DESCRIPTION
Adds the `preview` element from docgen generated documentation to the `overview` variable for mustache templates. One open question/comment is the `generate_site.dart` should expect a working directory of `Pixelate` not `Pixelate/bin`. 

To use the `components.json` needs to disable `flex_panel` since it does not follow the components folder structure.

```
  {
    "name": "Layout",
    "components": [
//      "flex_panel",
      "grid_panel"
    ]
  },

```
