### PR TITLE
Drone io sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ build
 
 # Documentation
 docs
+
+# gh-pages generation
+.docs_staging
+.web_staging

--- a/drone_io.sh
+++ b/drone_io.sh
@@ -23,7 +23,7 @@ mv dartdoc-viewer/client/out/web ./.docs_staging
 pub build web 
 
 # TODO: stage web
-cp -r web .web_staging
+cp -r build/web .web_staging
 
 # fetch origin
 git fetch origin

--- a/drone_io.sh
+++ b/drone_io.sh
@@ -16,13 +16,14 @@ rm dartdoc-viewer/client/out/web/static/packages
 rm dartdoc-viewer/client/out/web/static/js/packages
 rm dartdoc-viewer/client/out/web/static/css/packages
 
+# Stage doc files
 mv dartdoc-viewer/client/out/packages dartdoc-viewer/client/out/web/packages
 mv dartdoc-viewer/client/out/web ./.docs_staging
 
 # TODO: run pub build web.. This will transform Pixelate and proper packages folder
 pub build web 
 
-# TODO: stage web
+# stage web files
 cp -r build/web .web_staging
 
 # fetch origin
@@ -39,17 +40,14 @@ git checkout --track -b gh-pages origin/gh-pages
 
 # delete any files that might still be around.
 rm -rf *
+
+# unstage files
 date > date.txt
-# TODO: unstage .web_staging
-mv .web_staging web
-# TODO: At this point Pixelate might want to just `mv .docs_staging web/docs`
-mv .docs_staging web/docs
-# 
-#cd .docs_staging
-#cp -r . ..
-#cd ../
+cp -r .web_staging/* .
+cp -r .docs_staging docs
 rm -rf .docs_staging
 rm -rf .web_staging
+
 git add -A
 git commit -m"auto commit from drone"
 git remote set-url origin git@github.com:donny-dont/Pixelate.git

--- a/drone_io.sh
+++ b/drone_io.sh
@@ -1,0 +1,41 @@
+
+git clone https://github.com/donny-dont/Pixelate-Flat.git ../pixelate-flat
+pub install
+
+docgen --compile --package-root=./packages --no-include-sdk --include-private lib/*.dart
+
+rm dartdoc-viewer/client/out/web/packages
+rm dartdoc-viewer/client/out/web/docs/packages
+rm dartdoc-viewer/client/out/web/docs/Pixelate/packages
+
+rm dartdoc-viewer/client/out/web/static/packages
+rm dartdoc-viewer/client/out/web/static/js/packages
+rm dartdoc-viewer/client/out/web/static/css/packages
+
+mv dartdoc-viewer/client/out/packages dartdoc-viewer/client/out/web/packages
+mv dartdoc-viewer/client/out/web ./.docs_staging
+
+# fetch origin
+git fetch origin
+
+# get branches 
+git branch -v -a
+
+# delete any files that might still be around.
+rm -rf *
+
+# copy docs up to github gh-pages branch
+#git checkout gh-pages
+git checkout --track -b gh-pages origin/gh-pages
+
+# delete any files that might still be around.
+rm -rf *
+date > date.txt
+cd .docs_staging
+cp -r . ..
+cd ../
+rm -rf .docs_staging
+git add -A
+git commit -m"auto commit from drone"
+git remote set-url origin git@github.com:donny-dont/Pixelate.git
+git push origin gh-pages

--- a/drone_io.sh
+++ b/drone_io.sh
@@ -1,6 +1,10 @@
+#!/usr/bin/env bash
+set -o xtrace
 
 git clone https://github.com/donny-dont/Pixelate-Flat.git ../pixelate-flat
-pub install
+pub get
+
+# TODO: dartanalyzer on all libraries and main entry points in Pixelate 
 
 docgen --compile --package-root=./packages --no-include-sdk --include-private lib/*.dart
 
@@ -15,6 +19,12 @@ rm dartdoc-viewer/client/out/web/static/css/packages
 mv dartdoc-viewer/client/out/packages dartdoc-viewer/client/out/web/packages
 mv dartdoc-viewer/client/out/web ./.docs_staging
 
+# TODO: run pub build web.. This will transform Pixelate and proper packages folder
+pub build web 
+
+# TODO: stage web
+cp -r web .web_staging
+
 # fetch origin
 git fetch origin
 
@@ -25,16 +35,21 @@ git branch -v -a
 rm -rf *
 
 # copy docs up to github gh-pages branch
-#git checkout gh-pages
 git checkout --track -b gh-pages origin/gh-pages
 
 # delete any files that might still be around.
 rm -rf *
 date > date.txt
-cd .docs_staging
-cp -r . ..
-cd ../
+# TODO: unstage .web_staging
+mv .web_staging web
+# TODO: At this point Pixelate might want to just `mv .docs_staging web/docs`
+mv .docs_staging web/docs
+# 
+#cd .docs_staging
+#cp -r . ..
+#cd ../
 rm -rf .docs_staging
+rm -rf .web_staging
 git add -A
 git commit -m"auto commit from drone"
 git remote set-url origin git@github.com:donny-dont/Pixelate.git


### PR DESCRIPTION
Unable to test cause dartdoc-viewer is broken for dev channel sdk. Lets merge this PR and wire up the drone.io part when dartdoc-viewer is fixed. Bascially you dont want too much configuration in the drone io site, its easy to have a single shell script that is called from drone.io which drives all other tests to run. 
